### PR TITLE
删除不必要的http请求

### DIFF
--- a/deep-qa/src/main/java/org/apdplat/qa/datasource/GoogleDataSource.java
+++ b/deep-qa/src/main/java/org/apdplat/qa/datasource/GoogleDataSource.java
@@ -224,8 +224,7 @@ public class GoogleDataSource implements DataSource {
         try {
             HttpClient httpClient = new HttpClient();
             GetMethod getMethod = new GetMethod(query);
-
-            httpClient.executeMethod(getMethod);
+            
             getMethod.getParams().setParameter(HttpMethodParams.RETRY_HANDLER,
                     new DefaultHttpMethodRetryHandler());
 


### PR DESCRIPTION
删掉了第228行代码，后面第232行已经有一个executeMethod方法调用，没必要调用两遍。

其余部分没有diff，不知道github怎么搞得。。。标了一大堆diff。。
